### PR TITLE
Improve subschema loading w fs provider

### DIFF
--- a/src/jsonspec/reference/providers.py
+++ b/src/jsonspec/reference/providers.py
@@ -105,6 +105,11 @@ class FilesystemProvider(Provider):
                 spec = filename[l:-5]
                 with open(filename, 'r') as file:
                     schema = json.load(file)
+
+                # Let's assume the schema knows its name more accurately than its path can provide.
+                if schema.get('id'):
+                    spec = schema['id']
+
                 data[spec] = schema
 
             # set the fallbacks

--- a/src/jsonspec/reference/providers.py
+++ b/src/jsonspec/reference/providers.py
@@ -10,10 +10,10 @@ __all__ = ['Provider', 'FilesystemProvider', 'PkgProvider', 'SpecProvider']
 import json
 import logging
 import os
+import glob
 import pkg_resources
 from .bases import Provider
 from .exceptions import NotFound
-from .util import loop
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ class FilesystemProvider(Provider):
             data = {}
 
             l = len(self.directory)
-            for filename in loop(self.directory, '*.json'):
+            for filename in glob.glob(self.directory + '/**/*json'):
                 spec = filename[l:-5]
                 with open(filename, 'r') as file:
                     schema = json.load(file)

--- a/src/jsonspec/reference/util.py
+++ b/src/jsonspec/reference/util.py
@@ -4,7 +4,7 @@
 
 """
 
-__all__ = ['ref', 'loop', 'Mapping', 'MutableMapping']
+__all__ = ['ref', 'Mapping', 'MutableMapping']
 
 import fnmatch
 import os
@@ -17,21 +17,6 @@ def ref(obj):
         return obj['$ref']
     except (KeyError, TypeError):
         return None
-
-
-def loop(directory, pattern='*'):
-    regex = fnmatch.translate(pattern)
-    matcher = re.compile(regex)
-
-    def _loop(directory):
-        for file in os.listdir(directory):
-            path = os.path.join(directory, file)
-            if os.path.isfile(path) and matcher.match(path):
-                yield path
-            elif os.path.isdir(path):
-                for subpath in loop(path):
-                    yield subpath
-    return _loop(directory)
 
 
 try:


### PR DESCRIPTION
Schemas that have version information in their names (e.g. "/v1") were failing to load with the FilesystemProvider, which uses as the spec a path fragment.  This PR modifies this, such that if a schema includes an "id" field, it replaces the spec with that value, such on the assumption that inbound references are more likely to use this value than the path fragment.

Also, the old "util.loop" function was slurping up *.pyc files in my __pycache__ dirs, so I replaced it with the simpler standard library module glob, which achieves the same functionality with less code.