### PR TITLE
Added zip_safe=False flag so spec provider works.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages('src'),
     include_package_data=True,
+    zip_safe=False,
     keywords=[
         'json',
         'utilitaries',


### PR DESCRIPTION
The package data bundled with SpecProvider is unavailable, causing errors when using PkgProvider, if installed in recent versions of python3 which by default use containers for packages.  

Setting zip_safe=False ensures that the filesystem traversal operations used in SpecProvider are safe.  (Truthfully, a variation on FilesystemProvider using pkg_resources to traverse package contents would be hella useful...I'll see about adding that in a subsequent PR so that we can drop this flag, but in the meantime, this will allow the package to work with my code.)