### PR TITLE
fixing broken link for json ref

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -120,4 +120,4 @@ Defining providers
 .. autoclass:: reference.providers.SpecProvider
     :members:
 
-.. _`JSON Reference`: http://tools.ietf.org/html/draft-pbryan-zyp-ref-03
+.. _`JSON Reference`: http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03


### PR DESCRIPTION
Hi,

I saw that you had a link that seemed broken so I went ahead and fixed it here.  I'm interested in using your library, but I need a change in the functionality.  I need to be able to follow references all the way through.  So when I resolve a $ref that points to another $ref, it will resolve to the value and not to the reference.  Is there a reason you decided to place this limitation? 

If I were to make this change, would you be interested in a pull request?