### PR TITLE
use collections MutableMapping and MutableSequence in type checks

### DIFF
--- a/src/jsonspec/operations/bases.py
+++ b/src/jsonspec/operations/bases.py
@@ -10,7 +10,7 @@ __all__ = ['Target']
 from copy import deepcopy
 import logging
 from jsonspec.pointer import Pointer
-from collections import MutableMapping, MutableSequence
+from collections import Mapping, MutableSequence
 from jsonspec.pointer import ExtractError, OutOfBounds, OutOfRange, LastElement
 from .exceptions import Error, NonexistentTarget
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ class Target(object):
                 parent, obj = obj, token.extract(obj, bypass_ref=True)
 
             # removing
-            if isinstance(parent, MutableMapping):
+            if isinstance(parent, Mapping):
                 del parent[token]
 
             if isinstance(parent, MutableSequence):
@@ -105,7 +105,7 @@ class Target(object):
             else:
                 if isinstance(parent, MutableSequence):
                     raise OutOfRange(parent)
-                if isinstance(parent, MutableMapping):
+                if isinstance(parent, Mapping):
                     raise OutOfBounds(parent)
                 raise Error('already setted')
         except (OutOfBounds, OutOfRange, LastElement) as error:
@@ -138,7 +138,7 @@ class Target(object):
 
             # replace
             value = deepcopy(value)
-            if isinstance(parent, MutableMapping):
+            if isinstance(parent, Mapping):
                 parent[token] = value
 
             if isinstance(parent, MutableSequence):
@@ -177,7 +177,7 @@ class Target(object):
             parent, fragment = fragment, token.extract(fragment,
                                                        bypass_ref=True)
 
-        if isinstance(parent, MutableMapping):
+        if isinstance(parent, Mapping):
             del parent[token]
 
         if isinstance(parent, MutableSequence):

--- a/src/jsonspec/operations/bases.py
+++ b/src/jsonspec/operations/bases.py
@@ -10,6 +10,7 @@ __all__ = ['Target']
 from copy import deepcopy
 import logging
 from jsonspec.pointer import Pointer
+from collections import MutableMapping, MutableSequence
 from jsonspec.pointer import ExtractError, OutOfBounds, OutOfRange, LastElement
 from .exceptions import Error, NonexistentTarget
 logger = logging.getLogger(__name__)
@@ -58,10 +59,10 @@ class Target(object):
                 parent, obj = obj, token.extract(obj, bypass_ref=True)
 
             # removing
-            if isinstance(parent, dict):
+            if isinstance(parent, MutableMapping):
                 del parent[token]
 
-            if isinstance(parent, list):
+            if isinstance(parent, MutableSequence):
                 parent.pop(int(token))
         except Exception as error:
             raise Error(*error.args)
@@ -102,9 +103,9 @@ class Target(object):
             for token in Pointer(pointer):
                 parent, obj = obj, token.extract(obj, bypass_ref=True)
             else:
-                if isinstance(parent, list):
+                if isinstance(parent, MutableSequence):
                     raise OutOfRange(parent)
-                if isinstance(parent, dict):
+                if isinstance(parent, MutableMapping):
                     raise OutOfBounds(parent)
                 raise Error('already setted')
         except (OutOfBounds, OutOfRange, LastElement) as error:
@@ -137,10 +138,10 @@ class Target(object):
 
             # replace
             value = deepcopy(value)
-            if isinstance(parent, dict):
+            if isinstance(parent, MutableMapping):
                 parent[token] = value
 
-            if isinstance(parent, list):
+            if isinstance(parent, MutableSequence):
                 parent[int(token)] = value
         except Exception as error:
             raise Error(*error.args)
@@ -176,10 +177,10 @@ class Target(object):
             parent, fragment = fragment, token.extract(fragment,
                                                        bypass_ref=True)
 
-        if isinstance(parent, dict):
+        if isinstance(parent, MutableMapping):
             del parent[token]
 
-        if isinstance(parent, list):
+        if isinstance(parent, MutableSequence):
             parent.pop(int(token))
 
         # insert

--- a/src/jsonspec/pointer/bases.py
+++ b/src/jsonspec/pointer/bases.py
@@ -10,6 +10,7 @@ __all__ = ['DocumentPointer', 'Pointer', 'PointerToken']
 import logging
 from abc import abstractmethod, ABCMeta
 from six import add_metaclass, string_types
+from collections import MutableMapping, MutableSequence
 from .exceptions import ExtractError, RefError, LastElement, OutOfBounds, OutOfRange, WrongType, UnstagedError, ParseError  # noqa
 
 logger = logging.getLogger(__name__)
@@ -216,17 +217,17 @@ class ChildToken(PointerToken):
         :param bypass_ref: disable JSON Reference errors
         """
         try:
-            if isinstance(obj, dict):
+            if isinstance(obj, MutableMapping):
                 if not bypass_ref and '$ref' in obj:
                     raise RefError(obj, 'presence of a $ref member')
                 obj = self.extract_mapping(obj)
-            elif isinstance(obj, (list, tuple)):
+            elif isinstance(obj, MutableSequence):
                 obj = self.extract_sequence(obj)
             else:
                 raise WrongType(obj, '{!r} does not apply '
                                      'for {!r}'.format(str(self), obj))
 
-            if isinstance(obj, dict):
+            if isinstance(obj, MutableMapping):
                 if not bypass_ref and '$ref' in obj:
                     raise RefError(obj, 'presence of a $ref member')
             return obj

--- a/src/jsonspec/pointer/bases.py
+++ b/src/jsonspec/pointer/bases.py
@@ -10,7 +10,7 @@ __all__ = ['DocumentPointer', 'Pointer', 'PointerToken']
 import logging
 from abc import abstractmethod, ABCMeta
 from six import add_metaclass, string_types
-from collections import MutableMapping, MutableSequence
+from collections import Mapping, Sequence, MutableSequence
 from .exceptions import ExtractError, RefError, LastElement, OutOfBounds, OutOfRange, WrongType, UnstagedError, ParseError  # noqa
 
 logger = logging.getLogger(__name__)
@@ -217,17 +217,17 @@ class ChildToken(PointerToken):
         :param bypass_ref: disable JSON Reference errors
         """
         try:
-            if isinstance(obj, MutableMapping):
+            if isinstance(obj, Mapping):
                 if not bypass_ref and '$ref' in obj:
                     raise RefError(obj, 'presence of a $ref member')
                 obj = self.extract_mapping(obj)
-            elif isinstance(obj, MutableSequence):
+            elif isinstance(obj, Sequence) and not isinstance(obj, string_types):
                 obj = self.extract_sequence(obj)
             else:
                 raise WrongType(obj, '{!r} does not apply '
                                      'for {!r}'.format(str(self), obj))
 
-            if isinstance(obj, MutableMapping):
+            if isinstance(obj, Mapping):
                 if not bypass_ref and '$ref' in obj:
                     raise RefError(obj, 'presence of a $ref member')
             return obj

--- a/src/jsonspec/pointer/stages.py
+++ b/src/jsonspec/pointer/stages.py
@@ -3,7 +3,7 @@
     ~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-
+from collections import MutableMapping, MutableSequence
 
 class Staged(object):
     obj = None
@@ -54,10 +54,10 @@ def stage(obj, parent=None, member=None):
     """
     obj = Staged(obj, parent, member)
 
-    if isinstance(obj, dict):
+    if isinstance(obj, MutableMapping):
         for key, value in obj.items():
             stage(value, obj, key)
-    elif isinstance(obj, (list, tuple)):
+    elif isinstance(obj, MutableSequence):
         for index, value in enumerate(obj):
             stage(value, obj, index)
     elif isinstance(obj, set):

--- a/src/jsonspec/pointer/stages.py
+++ b/src/jsonspec/pointer/stages.py
@@ -3,7 +3,8 @@
     ~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-from collections import MutableMapping, MutableSequence
+from six import string_types
+from collections import Mapping, Sequence, Set
 
 class Staged(object):
     obj = None
@@ -54,13 +55,13 @@ def stage(obj, parent=None, member=None):
     """
     obj = Staged(obj, parent, member)
 
-    if isinstance(obj, MutableMapping):
+    if isinstance(obj, Mapping):
         for key, value in obj.items():
             stage(value, obj, key)
-    elif isinstance(obj, MutableSequence):
+    elif isinstance(obj, Sequence) and not isinstance(obj, string_types):
         for index, value in enumerate(obj):
             stage(value, obj, index)
-    elif isinstance(obj, set):
+    elif isinstance(obj, Set):
         for value in obj:
             stage(value, obj, None)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,13 +3,14 @@
     ~~~~~
 """
 
-__all__ = ['fixture', 'fixture_dir', 'TestCase']
+__all__ = ['fixture', 'fixture_dir', 'TestCase', 'TestMappingType', 'TestSequenceType']
 
 import json
 import logging
 import os.path
 import unittest
 from contextlib import contextmanager
+from collections import MutableMapping, MutableSequence
 
 logging.basicConfig(level=logging.INFO)
 
@@ -33,3 +34,23 @@ def move_cwd():
 
 class TestCase(unittest.TestCase):
     pass
+
+
+class TestMappingType(dict, MutableMapping):
+    def copy(self):
+        if self.__class__ is UserDict:
+            return UserDict(self.data.copy())
+        import copy
+        data = self.data
+        try:
+            self.data = {}
+            c = copy.copy(self)
+        finally:
+            self.data = data
+        c.update(self)
+        return c
+
+
+class TestSequenceType(list, MutableSequence):
+    def copy(self):
+        return self.__class__(self)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -5,7 +5,7 @@
 """
 
 import pytest
-from collections import UserDict, UserList
+from six.moves import UserDict, UserList
 from jsonspec.operations import check, remove, add, replace, copy, move
 from jsonspec.operations import Error, NonexistentTarget
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -5,10 +5,14 @@
 """
 
 import pytest
-from six.moves import UserDict, UserList
+from collections import Mapping, Sequence
+from . import TestMappingType, TestSequenceType
 from jsonspec.operations import check, remove, add, replace, copy, move
 from jsonspec.operations import Error, NonexistentTarget
 
+def test_types():
+    assert isinstance(TestMappingType(), Mapping)
+    assert isinstance(TestSequenceType(), Sequence)
 
 def test_check():
     assert check({'foo': 'bar'}, '/foo', 'bar')
@@ -183,7 +187,7 @@ def test_adding_array_value():
     }
 
 def test_adding_mapping_type_value():
-    obj = UserDict({'foo': UserList(['bar'])})
-    assert add(obj, '/foo/-', ['abc', 'def']) == {
+    obj = TestMappingType({'foo': ['bar']})
+    assert add(obj, '/foo/-', ['abc', 'def']) == TestMappingType({
         'foo': ['bar', ['abc', 'def']]
-    }
+    })

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -5,6 +5,7 @@
 """
 
 import pytest
+from collections import UserDict, UserList
 from jsonspec.operations import check, remove, add, replace, copy, move
 from jsonspec.operations import Error, NonexistentTarget
 
@@ -177,6 +178,12 @@ def test_comparing_strings_and_numbers():
 
 def test_adding_array_value():
     obj = {'foo': ['bar']}
+    assert add(obj, '/foo/-', ['abc', 'def']) == {
+        'foo': ['bar', ['abc', 'def']]
+    }
+
+def test_adding_mapping_type_value():
+    obj = UserDict({'foo': UserList(['bar'])})
     assert add(obj, '/foo/-', ['abc', 'def']) == {
         'foo': ['bar', ['abc', 'def']]
     }

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -4,8 +4,8 @@
 
 """
 
-from six.moves import UserDict, UserList
 from jsonspec.pointer import extract, stage
+from . import TestMappingType, TestSequenceType
 from jsonspec.pointer import RefError, DocumentPointer, Pointer
 from jsonspec.pointer import exceptions as events
 from . import TestCase
@@ -56,7 +56,7 @@ class TestPointer(TestCase):
 
 class TestSequence(TestCase):
     document = ['foo', 'bar', {'$ref': 'baz'}]
-    collections_document = UserList(['foo', 'bar', UserDict({'$ref': 'baz'})])
+    collections_document = TestSequenceType(['foo', 'bar', TestMappingType({'$ref': 'baz'})])
 
     def test_sequence(self):
         assert 'bar' == extract(self.document, '/1')
@@ -92,9 +92,10 @@ class TestSequence(TestCase):
             self.fail('last element needed')
         except events.WrongType as event:
             assert self.document == event.obj
+
 
 class TestSequenceType(TestCase):
-    document = UserList(['foo', 'bar', UserDict({'$ref': 'baz'})])
+    document = TestSequenceType(['foo', 'bar', TestMappingType({'$ref': 'baz'})])
 
     def test_sequence(self):
         assert 'bar' == extract(self.document, '/1')
@@ -130,6 +131,7 @@ class TestSequenceType(TestCase):
             self.fail('last element needed')
         except events.WrongType as event:
             assert self.document == event.obj
+
 
 class TestMapping(TestCase):
     document = {'foo': 42, 'bar': {'$ref': 'baz'}, 4: True}
@@ -164,8 +166,9 @@ class TestMapping(TestCase):
         except events.OutOfBounds as event:
             assert self.document == event.obj
 
+
 class TestMappingType(TestCase):
-    document = UserDict({'foo': 42, 'bar': UserDict({'$ref': 'baz'}), 4: True})
+    document = TestMappingType({'foo': 42, 'bar': TestMappingType({'$ref': 'baz'}), 4: True})
 
     def test_mapping(self):
         assert 42 == extract(self.document, '/foo')
@@ -196,6 +199,7 @@ class TestMappingType(TestCase):
             self.fail('out of bound')
         except events.OutOfBounds as event:
             assert self.document == event.obj
+
 
 class TestRelative(object):
     document = stage({

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -4,7 +4,7 @@
 
 """
 
-from collections import UserDict, UserList
+from six.moves import UserDict, UserList
 from jsonspec.pointer import extract, stage
 from jsonspec.pointer import RefError, DocumentPointer, Pointer
 from jsonspec.pointer import exceptions as events

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -4,6 +4,7 @@
 
 """
 
+from collections import UserDict, UserList
 from jsonspec.pointer import extract, stage
 from jsonspec.pointer import RefError, DocumentPointer, Pointer
 from jsonspec.pointer import exceptions as events
@@ -55,6 +56,7 @@ class TestPointer(TestCase):
 
 class TestSequence(TestCase):
     document = ['foo', 'bar', {'$ref': 'baz'}]
+    collections_document = UserList(['foo', 'bar', UserDict({'$ref': 'baz'})])
 
     def test_sequence(self):
         assert 'bar' == extract(self.document, '/1')
@@ -91,6 +93,43 @@ class TestSequence(TestCase):
         except events.WrongType as event:
             assert self.document == event.obj
 
+class TestSequenceType(TestCase):
+    document = UserList(['foo', 'bar', UserDict({'$ref': 'baz'})])
+
+    def test_sequence(self):
+        assert 'bar' == extract(self.document, '/1')
+
+    def test_last_element(self):
+        try:
+            extract(self.document, '/-')
+            self.fail('last element needed')
+        except events.LastElement as event:
+            assert self.document == event.obj
+
+    def test_ref(self):
+        try:
+            extract(self.document, '/2')
+            self.fail('last element needed')
+        except events.RefError as event:
+            assert self.document[2] == event.obj
+
+    def test_bypass_ref(self):
+        assert self.document[2] == extract(self.document, '/2',
+                                           bypass_ref=True)
+
+    def test_out_of_range(self):
+        try:
+            extract(self.document, '/3')
+            self.fail('last element needed')
+        except events.OutOfRange as event:
+            assert self.document == event.obj
+
+    def test_wrong_type(self):
+        try:
+            extract(self.document, '/foo')
+            self.fail('last element needed')
+        except events.WrongType as event:
+            assert self.document == event.obj
 
 class TestMapping(TestCase):
     document = {'foo': 42, 'bar': {'$ref': 'baz'}, 4: True}
@@ -125,6 +164,38 @@ class TestMapping(TestCase):
         except events.OutOfBounds as event:
             assert self.document == event.obj
 
+class TestMappingType(TestCase):
+    document = UserDict({'foo': 42, 'bar': UserDict({'$ref': 'baz'}), 4: True})
+
+    def test_mapping(self):
+        assert 42 == extract(self.document, '/foo')
+
+    def test_cast(self):
+        assert self.document[4] == extract(self.document, '/4')
+
+    def test_ref(self):
+        try:
+            extract(self.document, '/bar')
+            self.fail('last element needed')
+        except events.RefError as event:
+            assert self.document['bar'] == event.obj
+
+    def test_bypass_ref(self):
+        assert self.document['bar'] == extract(self.document, '/bar',
+                                               bypass_ref=True)
+
+    def test_out_of_bound(self):
+        try:
+            extract(self.document, '/3')
+            self.fail('out of bound')
+        except events.OutOfBounds as event:
+            assert self.document == event.obj
+
+        try:
+            extract(self.document, '/quux')
+            self.fail('out of bound')
+        except events.OutOfBounds as event:
+            assert self.document == event.obj
 
 class TestRelative(object):
     document = stage({


### PR DESCRIPTION
Operations were failing since I was using my own types. This pull checks for `collections.MutableMapping` and `collections.MutableSequence` instead of concrete types `dict`, `list`, `tuple`.