### PR TITLE
Fix link to on-line documentation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,5 +123,5 @@ Other examples can be found in the documentation_ or in the tests_.
 .. _`JSON Reference`: http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03
 .. _`JSON Pointer`: http://tools.ietf.org/html/rfc6901
 .. _`BSD license`: https://github.com/johnnoone/json-spec/blob/master/LICENSE
-.. _documentation: http://py.errorist.io/json-spec/
+.. _documentation: https://json-spec.readthedocs.io/
 .. _tests: https://github.com/johnnoone/json-spec/tree/master/tests


### PR DESCRIPTION
Currently, the `README.rst` file points to a URL at the site, `py.errorist.io`, which no longer exists.  According to PyPI, the documentation now resides at https://json-spec.readthedocs.io/.  This PR fixes the broken documentation link by pointing it to the readthedocs page.  