### PR TITLE
Fix command output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,22 +36,63 @@ This one will enable ip format for json schema::
 CLI Usage
 ---------
 
-This module expose 2 cli commands.
+This module expose a cli command with multiple operations.
 
+**json add** will transform the json document::
 
-**json-extract** will extract parts of your json document::
+    $ json add '#/foo/1' --fragment-file=fragment.json --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json add '#/foo/1' --fragment-json='first'
+    $ json add '#/foo/1' --fragment-file=fragment.json --document-file=doc.json
+    $ json add '#/foo/1' --fragment-file=fragment.json < doc.json
 
-    $ json-extract '#/foo/1' --document-json='{"foo": ["bar", "baz"]}'
-    $ echo '{"foo": ["bar", "baz"]}' | json-extract '#/foo/1'
-    $ json-extract '#/foo/1' --document-file=doc.json
-    $ json-extract '#/foo/1' < doc.json
+**json check** will test that a value at the target location is equal to a specified value::
 
-**json-validate** will validate your document against a schema::
+    $ json check '#/foo/1' --fragment-file=fragment.json --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json check '#/foo/1' --fragment-file=fragment.json
+    $ json check '#/foo/1' --fragment-file=fragment.json --document-file=doc.json
+    $ json check '#/foo/1' --fragment-file=fragment.json < doc.json
 
-    $ json-validate --schema-file=schema.json --document-json='{"foo": ["bar", "baz"]}'
-    $ echo '{"foo": ["bar", "baz"]}' | json-validate --schema-file=schema.json
-    $ json-validate --schema-file=schema.json --document-file=doc.json
-    $ json-validate --schema-file=schema.json < doc.json
+**json copy** will copy the value at a specified location to the target location::
+
+    $ json copy '#/foo/1' --target='#/foo/2' --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json copy '#/foo/1' --target='#/foo/2'
+    $ json copy '#/foo/1' --target='#/foo/2' --document-file=doc.json
+    $ json copy '#/foo/1' --target='#/foo/2' < doc.json
+
+**json extract** will extract parts of your json document::
+
+    $ json extract '#/foo/1' --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json extract '#/foo/1'
+    $ json extract '#/foo/1' --document-file=doc.json
+    $ json extract '#/foo/1' < doc.json
+
+**json move** will remove the value at a specified location and it will add the value to the target location::
+
+    $ json move '#/foo/2' --target='#/foo/1' --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json move '#/foo/2' --target='#/foo/1'
+    $ json move '#/foo/2' --target='#/foo/1' --document-file=doc.json
+    $ json move '#/foo/2' --target='#/foo/1' < doc.json
+
+**json remove** will remove the value at a specified location::
+
+    $ json remove '#/foo/1' --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json remove '#/foo/1'
+    $ json remove '#/foo/1' --document-file=doc.json
+    $ json remove '#/foo/1' < doc.json
+
+**json replace** will replace the value at a specified location with given fragment::
+
+    $ json replace '#/foo/1' --fragment-file=fragment.json --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json replace '#/foo/1' --fragment-file=fragment.json
+    $ json replace '#/foo/1' --fragment-file=fragment.json --document-file=doc.json
+    $ json replace '#/foo/1' --fragment-file=fragment.json < doc.json
+
+**json validate** will validate your document against a schema::
+
+    $ json validate --schema-file=schema.json --document-json='{"foo": ["bar", "baz"]}'
+    $ echo '{"foo": ["bar", "baz"]}' | json validate --schema-file=schema.json
+    $ json validate --schema-file=schema.json --document-file=doc.json
+    $ json validate --schema-file=schema.json < doc.json
 
 
 Library usage

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -127,7 +127,7 @@ Removes the value at a specified location and adds it to the target location.
 json remove
 -----------
 
-Removes the value at a specified location and adds it to the target location.
+Removes the value at a specified location.
 
 **Usage**
 
@@ -150,7 +150,7 @@ Removes the value at a specified location and adds it to the target location.
 json replace
 ------------
 
-Removes the value at a specified location and adds it to the target location.
+Replace the value at a specified location with the given fragment.
 
 **Usage**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "json-spec"
-version = "0.11.0"
+version = "0.11.1"
 description = "Implements JSON Schema, JSON Pointer and JSON Reference."
 authors = [ "Xavier Barbosa <clint.northwood@gmail.com>" ]
 license = "BSD-3-Clause"

--- a/src/jsonspec/cli.py
+++ b/src/jsonspec/cli.py
@@ -25,7 +25,6 @@ except ImportError:
 
 
 def disable_logging(func):
-    return func
     """
     Temporary disable logging.
     """
@@ -43,7 +42,6 @@ def disable_logging(func):
 
 
 def format_output(func):
-    return func
     """
     Format output.
     """
@@ -398,7 +396,7 @@ class MoveCommand(Command):
 
 
 class RemoveCommand(Command):
-    """Replace the value of pointer.
+    """Remove the value of pointer.
 
     examples:
       %(prog)s '#/foo/1' --document-json='{"foo": ["bar", "baz"]}'
@@ -509,7 +507,7 @@ def get_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
-    parser.add_argument("--version", action="version", version="%(prog)s 0.9.11")
+    parser.add_argument("--version", action="version", version="%(prog)s 0.11.1")
 
     subparsers = parser.add_subparsers(
         help="choose one of these actions", dest="action", metavar="<action>"


### PR DESCRIPTION
Currently, in Ubuntu installations the CLI command shows an empty output running any operation. The main problem detected was an early return of the original function in the wrapper function `format_output`.

The documentation has been updated and the version of the tool has been bumped to `0.11.1`.